### PR TITLE
Aging system in popular list

### DIFF
--- a/database/charts.py
+++ b/database/charts.py
@@ -211,12 +211,11 @@ def get_chart_list(
     if conditions:
         inner_select += " WHERE " + " AND ".join(conditions)
 
-    W_LIKE = 3
-    W_COMMENT = 4
-    W_STAFF = 30
+    W_LIKE = 4
+    W_PLAYER = 5
     GRAVITY = 0.35
 
-    score_expr = f"(like_count * {W_LIKE} + comment_count * {W_COMMENT} + (CASE WHEN staff_pick THEN {W_STAFF} ELSE 0 END))"
+    score_expr = f"(like_count * {W_LIKE} + unique_player_count * {W_PLAYER})"
 
     decaying_score_sql = f"""(
         ({score_expr}) 
@@ -299,6 +298,7 @@ def get_random_charts(
             c.rating,
             c.like_count,
             c.comment_count,
+            (SELECT COUNT(DISTINCT submitter) FROM leaderboards WHERE chart_id = c.id) AS unique_player_count,
             c.created_at,
             c.published_at,
             c.updated_at,


### PR DESCRIPTION
This PR replaces the existing cumulative popularity logic with a **Time Decay Algorithm** (based on Hacker News) to ensure the popular charts list stays fresh.

- Algorithm: Implemented the ranking formula: `(Score - 1) / (Time + 2)^Gravity`.
- Gravity: Set to **0.35**.
- This value allows popular charts to maintain their position for approximately **1 week** before decaying significantly.



**Performance Considerations**

- Real-time Calculation: The score is calculated dynamically during the `SELECT` query (on every view).
- Potential Impact: While this ensures accuracy, it may consume more server resources compared to the pre-calculated column approach. Be sure to test first before applying.
- Optimization Strategy: If performance issues arise, we can restrict the calculation scope (e.g., `WHERE published_at > NOW() - INTERVAL '30 days'`) to reduce the load.

**Notes on Legacy Logic**

- The previous `log_like_score` column and its associated DB triggers are no longer used for sorting. They can be removed in a future cleanup.
- Why change? The existing logic failed to apply time decay correctly, causing old popular charts to stick to the top indefinitely (infinite accumulation). If we decide to revert to a stored-value approach, the trigger logic must be fixed first.